### PR TITLE
Changed deactivate scope to remove scopes until the supplied scope is found

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -10,6 +10,7 @@ describe( "lux-keyboard", () => {
 		instance = proxyquire( "../src/index", {
 			"./KeyboardShortcutScope": {},
 			"./KeyboardInputManager": {},
+			"./keyboardShortcutWrapper": {},
 			"lux.js": { dispatch: dispatchStub },
 			"./MousetrapWrapper": { reset: resetStub }
 		} );

--- a/spec/keyboardInputStore.spec.js
+++ b/spec/keyboardInputStore.spec.js
@@ -170,6 +170,30 @@ describe( "keyboardInputStore", () => {
 					state.scopeStack.should.eql( [ [ "testThree" ], [ "test" ] ] );
 				} );
 			} );
+
+			describe( "when removing a scope that is not the active scope", () => {
+				describe( "when the scope group ends up empty", () => {
+					it( "should leave other scopes and remove the matching scope group", () => {
+						const state = store.getState();
+						state.scopeStack = [ [ "testThree" ], [ "test", "testTwo" ], [ "testZero" ] ];
+
+						dispatch( "deactivateScope", "testTwo" );
+
+						state.scopeStack.should.eql( [ [ "testThree" ], [ "test" ], [ "testZero" ] ] );
+					} );
+				} );
+
+				describe( "when the scope group still has additional scopes", () => {
+					it( "should leave other scopes and the matching scope group (minus the supplied scope)", () => {
+						const state = store.getState();
+						state.scopeStack = [ [ "testThree" ], [ "test" ], [ "testZero" ] ];
+
+						dispatch( "deactivateScope", "test" );
+
+						state.scopeStack.should.eql( [ [ "testThree" ], [ "testZero" ] ] );
+					} );
+				} );
+			} );
 		} );
 	} );
 

--- a/spec/keyboardShortcutWrapper.spec.js
+++ b/spec/keyboardShortcutWrapper.spec.js
@@ -1,0 +1,149 @@
+import { mount } from "enzyme";
+
+describe( "keyboardShortcutWrapper", () => {
+	let dispatchStub, TestComponent, WrappedComponent, wrapper, component;
+
+	function render( props = {}, options = {} ) {
+		WrappedComponent = wrapper( TestComponent, options );
+		component = mount( <WrappedComponent { ...props } /> );
+	}
+
+	beforeEach( () => {
+		TestComponent = React.createClass( {
+			render() {
+				return <span { ...this.props } />;
+			}
+		} );
+
+		dispatchStub = sinon.stub();
+		wrapper = proxyquire( "../src/keyboardShortcutWrapper", {
+			"lux.js": {
+				dispatch: dispatchStub
+			}
+		} );
+	} );
+
+	describe( "when mounting", () => {
+		describe( "when an initialScopeToActivate is provided", () => {
+			it( "should activate the scope", () => {
+				render( {}, { initialScopeToActivate: "test-scope" } );
+
+				dispatchStub.should.be.calledOnce
+					.and.calledWith( "activateScope", "test-scope" );
+			} );
+		} );
+
+		describe( "when no initialScopeToActivate is provided", () => {
+			it( "should not try to activate a scope", () => {
+				render();
+
+				dispatchStub.should.not.be.called();
+			} );
+		} );
+	} );
+
+	describe( "when unmounting", () => {
+		it( "should deactivate any active scopes", () => {
+			render( {}, { initialScopeToActivate: "test-scope" } );
+
+			const { activateScope, deactivateScope } = component.instance();
+
+			activateScope( "test-scope2" );
+			activateScope( "test-scope3" );
+			deactivateScope( "test-scope2" );
+
+			dispatchStub.reset();
+
+			component.unmount();
+
+			dispatchStub.should.be.calledTwice
+				.and.calledWith( "deactivateScope", "test-scope" )
+				.and.calledWith( "deactivateScope", "test-scope3" );
+		} );
+	} );
+
+	describe( "when rendering", () => {
+		it( "should render the supplied component", () => {
+			render();
+
+			component.find( TestComponent ).should.be.present();
+		} );
+
+		it( "should pass props down the the component", () => {
+			render( { foo: "bar" } );
+
+			component.find( TestComponent ).should.have.prop( "foo", "bar" );
+		} );
+
+		it( "should provide an activeScope prop", () => {
+			render();
+
+			component.find( TestComponent ).prop( "activateScope" ).should.be.a( "function" );
+		} );
+
+		it( "should provide a deactiveScope prop", () => {
+			render();
+
+			component.find( TestComponent ).prop( "deactivateScope" ).should.be.a( "function" );
+		} );
+
+		it( "should add a displayName", () => {
+			render();
+
+			WrappedComponent.displayName.should.equal( "KeyboardShortcutWrapper(TestComponent)" );
+		} );
+
+		it( "should handle adding a display name when the component has none", () => {
+			const Component = wrapper( () => {} );
+			Component.displayName.should.equal( "KeyboardShortcutWrapper(Component)" );
+		} );
+	} );
+
+	describe( "when activating scopes", () => {
+		let activateScope;
+
+		beforeEach( () => {
+			render();
+
+			activateScope = component.instance().activateScope;
+
+			activateScope( "new-scope" );
+		} );
+
+		it( "should activate the scope, if it is not active", () => {
+			dispatchStub.should.be.calledOnce
+				.and.calledWith( "activateScope", "new-scope" );
+		} );
+
+		it( "should not activate the scope again, if it is already active", () => {
+			dispatchStub.reset();
+
+			activateScope( "new-scope" );
+
+			dispatchStub.should.not.be.called();
+		} );
+	} );
+
+	describe( "when deactivating scopes", () => {
+		let deactivateScope;
+
+		beforeEach( () => {
+			render( {}, { initialScopeToActivate: "new-scope" } );
+			deactivateScope = component.instance().deactivateScope;
+			dispatchStub.reset();
+		} );
+
+		it( "should deactivate the scope, if it is active", () => {
+			deactivateScope( "new-scope" );
+
+			dispatchStub.should.be.calledOnce
+				.and.calledWith( "deactivateScope", "new-scope" );
+		} );
+
+		it( "should not deactivate the scope, if it is not active", () => {
+			deactivateScope( "some-other-scope" );
+
+			dispatchStub.should.not.be.called();
+		} );
+	} );
+} );

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import Mousetrap from "./MousetrapWrapper";
 
 export { default as KeyboardShortcutScope } from "./KeyboardShortcutScope";
 export { default as KeyboardInputManager } from "./KeyboardInputManager";
-
+export { default as keyboardShortcutWrapper } from "./keyboardShortcutWrapper";
 /*
 	Example structure of keyMaps arg:
 

--- a/src/keyboardInputStore.js
+++ b/src/keyboardInputStore.js
@@ -47,11 +47,18 @@ export default new Store( {
 		},
 		deactivateScope( scopeName ) {
 			const { scopeStack } = this.getState();
-			const activeScope = scopeStack[ scopeStack.length - 1 ];
-			remove( activeScope, name => name === scopeName );
-			if ( isEmpty( activeScope ) ) {
-				scopeStack.pop();
+
+			for ( let i = scopeStack.length - 1; i >= 0; i-- ) {
+				const activeScope = scopeStack[ i ];
+				if ( activeScope.includes( scopeName ) ) {
+					remove( activeScope, name => name === scopeName );
+					if ( isEmpty( activeScope ) ) {
+						scopeStack.splice( i, 1 );
+					}
+					break;
+				}
 			}
+
 			this.setState( { scopeStack } );
 		}
 	},

--- a/src/keyboardShortcutWrapper.js
+++ b/src/keyboardShortcutWrapper.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { dispatch } from "lux.js";
+
+export default function keyboardShortcutWrapper( Component, { initialScopeToActivate } = {} ) {
+	class KeyboardShortcutWrappedComponent extends React.Component {
+		constructor( props, context ) {
+			super( props, context );
+
+			this.activeScopes = new Set();
+			this.activateScope = scope => {
+				if ( !this.activeScopes.has( scope ) ) {
+					this.activeScopes.add( scope );
+					dispatch( "activateScope", scope );
+				}
+			};
+			this.deactivateScope = scope => {
+				if ( this.activeScopes.has( scope ) ) {
+					this.activeScopes.delete( scope );
+					dispatch( "deactivateScope", scope );
+				}
+			};
+		}
+
+		componentDidMount() {
+			if ( initialScopeToActivate ) {
+				this.activateScope( initialScopeToActivate );
+			}
+		}
+
+		componentWillUnmount() {
+			for ( const scope of this.activeScopes ) {
+				this.deactivateScope( scope );
+			}
+		}
+
+		render() {
+			return (
+				<Component
+					activateScope={ this.activateScope }
+					deactivateScope={ this.deactivateScope }
+					{...this.props } />
+			);
+		}
+	}
+
+	KeyboardShortcutWrappedComponent.displayName = `KeyboardShortcutWrapper(${ Component.displayName || "Component" })`;
+
+	return KeyboardShortcutWrappedComponent;
+}


### PR DESCRIPTION
- The `deactivateScope` handler now removes active scopes until it finds the supplied scope. This helps in scenarios where parent `componentWillUnmount` handlers run before the children.